### PR TITLE
Fix: local page actions issue // recovers setSection effects

### DIFF
--- a/src/app/pages/local/local-actions.js
+++ b/src/app/pages/local/local-actions.js
@@ -1,6 +1,0 @@
-import { createAction } from 'redux-actions'
-
-export const selectSelector = createAction('local:selectSelector')
-export const toggleLayer = createAction('local:toggleLayer')
-export const setSection = createAction('local:setSection')
-export const resetLayers = createAction('local:resetLayers')

--- a/src/app/pages/local/local-reducers.js
+++ b/src/app/pages/local/local-reducers.js
@@ -1,5 +1,4 @@
 import { actions as popUpActions } from 'components/pop-up'
-import { actions as mapActions, reducers as mapReducers } from 'pages/map'
 
 export default {
   [popUpActions.openPopUp]: (state, { payload }) => ({
@@ -13,6 +12,5 @@ export default {
   [popUpActions.closePopUp]: (state, { payload }) => ({
     ...state,
     popUp: { ...state.popUp, open: false, selected: null }
-  }),
-  [mapActions.resetLayers]: (state, payload) => mapReducers.resetLayers
+  })
 }

--- a/src/app/pages/local/local.js
+++ b/src/app/pages/local/local.js
@@ -1,9 +1,6 @@
 import { connect } from 'react-redux'
 
 import LocalComponent from './local-component'
-import * as actions from './local-actions'
-import { actions as mapActions } from 'pages/map'
-import { actions as sectionActions } from 'providers/section'
 import { actions as popUpActions } from 'components/pop-up'
 import reducers from './local-reducers'
 import initialState from './initial-state'
@@ -15,9 +12,7 @@ const mapStateToProps = ({ map, local, sidebar }) => ({
   renderToggle: renderToggle(map.layers)
 })
 
-export { actions, reducers, initialState }
+export { reducers, initialState }
 export default connect(mapStateToProps, {
-  ...mapActions,
-  ...sectionActions,
   ...popUpActions
 })(LocalComponent)

--- a/src/app/reducers.js
+++ b/src/app/reducers.js
@@ -49,7 +49,6 @@ import {
 } from 'pages/global'
 
 import {
-  actions as localActions,
   reducers as localReducers,
   initialState as localState
 } from 'pages/local'
@@ -69,8 +68,7 @@ const allActions = {
   ...selectorActions,
   ...regionalActions,
   ...globalActions,
-  ...popUpActions,
-  ...localActions
+  ...popUpActions
 }
 
 export default combineReducers({


### PR DESCRIPTION
This PR includes:
- Changes in Local page that remove unnecessary actions.
- Prevents local setSection action squashing other setSection actions.
- Completely removes intro -> local transitioning bug. Hooray 🎉 