### PR TITLE
Fix: header height iframe

### DIFF
--- a/src/app/layout/layout-styles.scss
+++ b/src/app/layout/layout-styles.scss
@@ -4,6 +4,7 @@
   position: fixed;
   width: 100vw;
   height: 100vw;
+  top: $header-height;
 
   .header {
     // height: 5rem;

--- a/src/app/styles/variables.scss
+++ b/src/app/styles/variables.scss
@@ -4,7 +4,7 @@ $zforeground: 10;
 
 $gutter: 1rem;
 $column-width: 40vw;
-$header-height: 0;//10rem;
+$header-height: 10rem;
 $max-width: 600px;
 $min-width: 430px;
 $sidebar-header-height: 115px;


### PR DESCRIPTION
This PR addresses:
- Texts are not scrollable because the `$header-height` was zero and in some places the styles where doing some things that are not supported like `calc(100vh - 0 -150px)`.
    - restores the `$header-height` and add a top: `$header-height` to the layout container.
