### PR TITLE
Fix artifacts and apply terrain exaggeration

### DIFF
--- a/src/app/components/v2/map/grid-layer/grid-layer.js
+++ b/src/app/components/v2/map/grid-layer/grid-layer.js
@@ -85,7 +85,7 @@ class GridLayer extends Component {
       this.primitive = new Cesium.Primitive({
         geometryInstances,
         // Needed to style each one on a different way
-        appearance: new Cesium.PerInstanceColorAppearance(),
+        appearance: new Cesium.PerInstanceColorAppearance({ flat: true }),
         interleave: true,
         vertexCacheOptimize: true,
         compressVertices: true,

--- a/src/app/components/v2/map/map.js
+++ b/src/app/components/v2/map/map.js
@@ -29,6 +29,7 @@ class CesiumComponent extends Component {
     creditsDisplay: false,
     fullscreenButton: false,
     skyAtmosphere: false,
+    terrainExaggeration: 2.0,
     // imageryProvider: new Cesium.UrlTemplateImageryProvider({
     //   url: `https://api.mapbox.com/styles/v1/jchalfearth/cj85y2wq523um2rryqnvxzlt1/tiles/256/{z}/{x}/{y}?access_token=${MAPBOX_TOKEN}`
     // })


### PR DESCRIPTION
This PR fixes some shadow artifacts on grid polygons.

![tiles](https://user-images.githubusercontent.com/6906348/46155205-0e343780-c277-11e8-95ff-3f6a4e792dbc.gif)

It also adds some terrain exaggeration factor to terrain model.