### PR TITLE
Restore the previous cell grid style when different grids

### DIFF
--- a/src/app/pages/root/map/map-component.jsx
+++ b/src/app/pages/root/map/map-component.jsx
@@ -54,7 +54,9 @@ class MapComponent extends PureComponent {
         );
       }
       if (this.lastObjId) {
-        const lastAttributes = primitive.getGeometryInstanceAttributes(this.lastObjId);
+        const lastGridLayer = this.gridLayers[this.lastObjId.slug];
+        const lastAttributes = lastGridLayer &&
+          lastGridLayer.primitive.getGeometryInstanceAttributes(this.lastObjId);
         if (lastAttributes) {
           lastAttributes.color = Cesium.ColorGeometryInstanceAttribute.toValue(
             Cesium.Color.WHITE.withAlpha(0.01)


### PR DESCRIPTION
No more forgotten cells when hovering, so this 🔢PR restores the previous styles independant of the cellgrid layer.

![kapture 2018-10-02 at 17 19 15](https://user-images.githubusercontent.com/10500650/46358499-5f716c00-c667-11e8-980d-65b4170c94e5.gif)
