### PR TITLE
Fix persistent gridCell bug

### DIFF
--- a/src/app/components/v2/map/map.js
+++ b/src/app/components/v2/map/map.js
@@ -69,7 +69,7 @@ class CesiumComponent extends Component {
       if (lockNavigation) disablePanning(this.viewer);
       if (terrainMode) {
         if (cellCoordinates) {
-          this.renderGridCell(cellCoordinates);
+          this.renderGridCell(cellCoordinates, this.rectangle);
           this.setTerrainModeView(cellCoordinates, terrainCameraOffset);
         }
       } else {
@@ -116,7 +116,8 @@ class CesiumComponent extends Component {
     }
   };
 
-  renderGridCell(cellCoordinates) {
+  renderGridCell(cellCoordinates, rectangle) {
+    if (rectangle) return null;
     const coordinates = Cesium.Rectangle.fromCartesianArray(cellCoordinates);
     this.rectangle = new Cesium.Entity({
       rectangle: {
@@ -127,7 +128,7 @@ class CesiumComponent extends Component {
         outlineColor: Cesium.Color.fromAlpha(Cesium.Color.WHITE, 0.9)
       }
     });
-    this.viewer.entities.add(this.rectangle);
+    return this.viewer.entities.add(this.rectangle);
   }
 
   setTerrainModeView(cellCoordinates, terrainCameraOffset) {
@@ -139,6 +140,7 @@ class CesiumComponent extends Component {
 
   removeGridCell() {
     this.viewer.entities.remove(this.rectangle);
+    this.rectangle = undefined;
   }
 
   setCoordinates() {

--- a/src/app/pages/root/detail-view/species-to-watch/species-to-watch-component.jsx
+++ b/src/app/pages/root/detail-view/species-to-watch/species-to-watch-component.jsx
@@ -12,7 +12,7 @@ class SpeciesToWatchComponent extends Component {
         <p className={styles.title}>List of species to watch in this area</p>
         {
           loading ? <Loading height="300" /> : data && data.length > 0 && data.map(specie => (
-            <div className={styles.speciesRow} key={specie.commonname}>
+            <div className={styles.speciesRow} key={specie.commonname || specie.scientificname}>
               {
                     (
                       <a href={specie.rangemap} target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
This PR fixes two bugs:
- Avoid creating various instances of the grid cell to properly delete the one that has been drawn.
- Add an alternative key on speciesToWatch component to avoid react same key error.