### PR TITLE
Fix/datasets position order

### DIFF
--- a/src/app/pages/root/categories-list/categories-list-component.jsx
+++ b/src/app/pages/root/categories-list/categories-list-component.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Button, Icon } from 'he-components';
+import { sortBy } from 'lodash';
 import DatasetCombo from 'components/v2/dataset-combo';
 
 import infoIcon from 'assets/icons/icon-info.svg';
@@ -21,6 +22,8 @@ class CategoriesListComponent extends Component {
   }
 
   renderRegularCategory(category) {
+    const { datasets } = category;
+    const sortedDatasets = sortBy(datasets, 'position');
     return (
       <div className={styles.category} key={category.slug}>
         <div>
@@ -29,7 +32,7 @@ class CategoriesListComponent extends Component {
             {category.metadata && this.renderInfoButton(category)}
           </div>
           <p className={styles.categoryDescription}>{category.description}</p>
-          {category.datasets.map(dataset => (
+          {sortedDatasets.map(dataset => (
             <DatasetCombo
               dataset={dataset}
               category={category}

--- a/src/app/pages/root/categories-list/categories-list-component.jsx
+++ b/src/app/pages/root/categories-list/categories-list-component.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Button, Icon } from 'he-components';
-import { sortBy } from 'lodash';
 import DatasetCombo from 'components/v2/dataset-combo';
 
 import infoIcon from 'assets/icons/icon-info.svg';
@@ -23,7 +22,6 @@ class CategoriesListComponent extends Component {
 
   renderRegularCategory(category) {
     const { datasets } = category;
-    const sortedDatasets = sortBy(datasets, 'position');
     return (
       <div className={styles.category} key={category.slug}>
         <div>
@@ -32,7 +30,7 @@ class CategoriesListComponent extends Component {
             {category.metadata && this.renderInfoButton(category)}
           </div>
           <p className={styles.categoryDescription}>{category.description}</p>
-          {sortedDatasets.map(dataset => (
+          {datasets.map(dataset => (
             <DatasetCombo
               dataset={dataset}
               category={category}

--- a/src/app/pages/root/group-card-list/group-card-list-component.jsx
+++ b/src/app/pages/root/group-card-list/group-card-list-component.jsx
@@ -12,28 +12,16 @@ class GroupCardListComponent extends Component {
     return (
       <div className={styles.groupCardListContainer}>
         {
-          categoriesGroups && categoriesGroups.map(
-              group =>
-                group.slug !== 'half-earth-view'
-                  ? (
-                    <AccordionCard
-                      key={group.slug}
-                      isOpen={group.isOpen}
-                      title={group.title}
-                      counter={group.layersActive > 0 ? group.layersActive : null}
-                    >
-                      <CategoriesList categories={group.categories} />
-                    </AccordionCard>
-)
-                  : (
-                    <div key={group.slug} className={styles.cardContainer}>
-                      <div className={styles.headerContainer}>
-                        <h2 className={styles.groupTitle}>{group.title}</h2>
-                      </div>
-                      <CategoriesList categories={group.categories} />
-                    </div>
-)
-            )
+          categoriesGroups && categoriesGroups.map(group => (
+            <AccordionCard
+              key={group.slug}
+              isOpen={group.isOpen}
+              title={group.title}
+              counter={group.layersActive > 0 ? group.layersActive : null}
+            >
+              <CategoriesList categories={group.categories} />
+            </AccordionCard>
+            ))
         }
       </div>
     );

--- a/src/app/selectors/categories-selectors.js
+++ b/src/app/selectors/categories-selectors.js
@@ -1,7 +1,6 @@
 import { createSelector } from 'reselect';
 import { getDatasets } from 'selectors/datasets-selectors';
 import orderBy from 'lodash/orderBy';
-import sortBy from 'lodash/sortBy';
 
 export const selectCategories = ({ categories = {} }) => categories.data;
 export const selectCategoriesLoading = ({ categories = {} }) => categories.loading;
@@ -12,11 +11,8 @@ export const getDatasetsByCategory = createSelector([ getDatasets, selectCategor
 ) =>
   {
     if (!datasets || !categories) return null;
-    return sortBy(
-      categories.map(category => {
-        const categoryDatasets = datasets.filter(d => d.category === category.slug);
-        return { ...category, datasets: orderBy(categoryDatasets, 'name') };
-      }),
-      'position'
-    );
+    return categories.map(category => {
+      const categoryDatasets = datasets.filter(d => d.category === category.slug);
+      return { ...category, datasets: orderBy(categoryDatasets, [ 'position', 'name' ]) };
+    });
   });


### PR DESCRIPTION
This PR orders datasets by `position` property, in case it is not `null`, otherwise alphabetical order remains.
[Pivotal task](https://www.pivotaltracker.com/story/show/160956193)

![kapture 2018-10-04 at 9 59 55](https://user-images.githubusercontent.com/6906348/46460465-5645e380-c7bc-11e8-9563-a6ec4ac3d7f8.gif)
