### PR TITLE
Fix/landscape dropdown selection

### DIFF
--- a/src/app/pages/root/detail-view/detail-view.js
+++ b/src/app/pages/root/detail-view/detail-view.js
@@ -20,6 +20,7 @@ class DetailViewContainer extends Component {
     updateQueryParam({
       query: {
         ...query,
+        taxa: undefined,
         cellId: undefined,
         terrain: undefined,
         terrainCameraOffset: undefined,
@@ -48,7 +49,7 @@ DetailViewContainer.propTypes = {
   query: PropTypes.object.isRequired,
   fetchCellDetail: PropTypes.func.isRequired,
   updateQueryParam: PropTypes.func.isRequired,
-  cellId: PropTypes.number.isRequired
+  cellId: PropTypes.string.isRequired
 };
 
 export default connect(mapStateToProps, actions)(DetailViewContainer);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4531,9 +4531,9 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-"he-components@github:vizzuality/half-earth-components#0.2.0":
+"he-components@github:vizzuality/half-earth-components#0.2.1":
   version "0.1.0"
-  resolved "https://codeload.github.com/vizzuality/half-earth-components/tar.gz/82fe9cb23f9dbe38f28abdd9f21c4e9954e7e304"
+  resolved "https://codeload.github.com/vizzuality/half-earth-components/tar.gz/26d0aa41403fc33fed5167352a698eef7b225652"
   dependencies:
     dotenv "6.0.0"
     react-modal "3.5.1"


### PR DESCRIPTION
This PR avoids detail view sidebar 
to crash after going from landscape view in a marine grid cell to a terrestrial grid cell and vice versa.

[Pivotal task](https://www.pivotaltracker.com/story/show/161014559)

![kapture 2018-10-08 at 11 41 32](https://user-images.githubusercontent.com/6906348/46601996-392c5000-caef-11e8-9017-ab9bd4670bc9.gif)
