### PR TITLE
Adjust setMapLayers to new activeLayers URL format

### DIFF
--- a/src/app/pages/root/map/map.js
+++ b/src/app/pages/root/map/map.js
@@ -32,7 +32,14 @@ class MapContainer extends Component {
     });
     postRobot.on('setMapLayers', event => {
       const { layers = [] } = event.data;
-      this.updateMapParams({ activeLayers: layers });
+      const activeLayers = layers.map(layer => ({
+        slug: layer,
+        active: true,
+        opacity: 1,
+        landscapeOpacity: null,
+        layerCateogry: null
+      }));
+      this.updateMapParams({ activeLayers });
       return { done: true };
     });
   }


### PR DESCRIPTION
This PR fixes an issue that we were having with the postRobot setMapLayers method, which wasn't working since we changed the way the activeLayers were handled on the URL.

To keep the same API format I just pick up the slugs and transform them into the activeLayers object with active status set to true and the correct slug, and nulls for the remaining values.