### PR TITLE
Update conservation areas behaviour

### DIFF
--- a/src/app/pages/root/detail-view/detail-view-selectors.js
+++ b/src/app/pages/root/detail-view/detail-view-selectors.js
@@ -85,8 +85,6 @@ export const getConservationCategory = createSelector(
   (data, categories) => {
     if (!data || !categories) return null;
     const category = categories.find(d => d.slug === 'conservation-areas');
-    // We want multiselection on the globe but not here
-    category.multiSelect = false;
     return category ? getLayersPercentage(category, data) : null;
   }
 );

--- a/src/app/pages/root/detail-view/progress-card/progress-card-component.jsx
+++ b/src/app/pages/root/detail-view/progress-card/progress-card-component.jsx
@@ -5,18 +5,28 @@ import { ProgressBar } from 'he-components';
 import DatasetCombo from 'components/v2/dataset-combo';
 
 import styles from './progress-card-styles';
+import disabledTheme from './progressbar-disabled-styles';
 
 class ProgressBarComponent extends Component {
   render() {
     const { category } = this.props;
+    const { multiSelect } = category;
     const layers = category &&
       category.datasets.reduce((acc, dataset) => [ ...acc, ...dataset.layers ], []);
     const layerActive = layers && layers.find(l => l.active) || {};
+    const disableProgressBar = multiSelect && layers.filter(l => l.active).length > 1;
+    const theme = disableProgressBar ? disabledTheme : {};
     return (
       <div className={cx({ [styles.containerSpaced]: !category.hideProgress })}>
         {
           !category.hideProgress &&
-            <ProgressBar percentage={layerActive.percentage || 0} label={layerActive.name || ''} />
+            (
+              <ProgressBar
+                percentage={layerActive.percentage || 0}
+                label={layerActive.name || ''}
+                theme={theme}
+              />
+            )
         }
         {category.description && <p className={styles.subtitle}>{category.description}</p>}
         {

--- a/src/app/pages/root/detail-view/progress-card/progressbar-disabled-styles.scss
+++ b/src/app/pages/root/detail-view/progress-card/progressbar-disabled-styles.scss
@@ -1,0 +1,6 @@
+.progress,
+.percentageLabel,
+.label {
+  opacity: 0;
+}
+


### PR DESCRIPTION
This PR updates conservation areas selectors on landscape mode.
It allows multiselection but avoids displaying percentages on the progress bar when more than a layer is selected.
[Pivotal task](https://www.pivotaltracker.com/story/show/161125506)

![kapture 2018-10-10 at 22 05 02](https://user-images.githubusercontent.com/6906348/46762904-a51ddc80-ccd8-11e8-89b4-e5a8c0550f88.gif)
 