### PR TITLE
Fix/landscape hovering events

### DIFF
--- a/src/app/components/v2/map/map.js
+++ b/src/app/components/v2/map/map.js
@@ -29,6 +29,7 @@ class CesiumComponent extends Component {
     creditsDisplay: false,
     fullscreenButton: false,
     terrainExaggeration: 2.0,
+    requestRenderMode: true,
     terrainProvider: Cesium.createWorldTerrain()
   };
 

--- a/src/app/components/v2/map/protected-areas-layer/protected-areas-layer.js
+++ b/src/app/components/v2/map/protected-areas-layer/protected-areas-layer.js
@@ -58,9 +58,9 @@ class ProtectedAreasLayer extends Component {
   }
 
   async renderAreas(conservationAreasActive) {
-    const { gridCellCoordinates, gridLayers } = this.props;
+    const { gridCellCoordinates, layers } = this.props;
     const areasToFetch = conservationAreasActive.map(ca => ca.slug);
-    const layersConfig = gridLayers.reduce(
+    const layersConfig = layers.reduce(
       (acc, l) => {
         let areaConfig;
         areasToFetch.forEach(area => {

--- a/src/app/pages/root/map/map-selectors.js
+++ b/src/app/pages/root/map/map-selectors.js
@@ -20,10 +20,15 @@ export const getLayersFiltered = createSelector([ getLayers ], datasets => {
 
 export const getGridLayers = createSelector([ getLayers ], layers => {
   if (!layers) return undefined;
-  return layers.filter(d => d.dataset === 'grids');
+  return layers.filter(d => d.dataset === 'grids' && !d.id.includes('protected'));
 });
 
-export const getProtectedAreasLayer = createSelector([ getLayersFiltered ], layers => {
+export const getProtectedAreasLayers = createSelector([ getLayers ], layers => {
+  if (!layers) return undefined;
+  return layers.filter(d => d.dataset === 'grids' && d.id.includes('protected'));
+});
+
+export const getProtectedAreasActive = createSelector([ getLayersFiltered ], layers => {
   if (!layers) return undefined;
   return layers.filter(d => d.dataset.includes('protected'));
 });
@@ -67,7 +72,8 @@ export const getGridCellId = createSelector([ selectQueryParams ], query => {
 export const mapStateToProps = createStructuredSelector({
   layers: getLayersFiltered,
   gridLayers: getGridLayers,
-  protectedAreasLayer: getProtectedAreasLayer,
+  protectedAreasAcive: getProtectedAreasActive,
+  protectedAreasLayers: getProtectedAreasLayers,
   terrainMode: getIsTerrain,
   query: selectQueryParams,
   coordinates: getCoordinates,


### PR DESCRIPTION
This PR avoids grid cell selection when hovering outside the map element.
Bug reported on [this](https://www.pivotaltracker.com/story/show/161212991) PT task

Extras:
-  Add `waterMask` to `scene` and display `skyAtmosphere` only on landscape mode.
-  Add `requestRenderMode` to avoid re rendering the scene if not needed. We will have to `scene.requestRender()` explicitly after some scenarios, for more context check:
 https://cesium.com/blog/2018/01/24/cesium-scene-rendering-performance/


![kapture 2018-10-17 at 13 12 06](https://user-images.githubusercontent.com/6906348/47082598-61623000-d20e-11e8-9193-a5c3f665c8cb.gif)
