### PR TITLE
Uses production URL for the share modal

### DIFF
--- a/src/app/components/v2/modal-share/modal-share.js
+++ b/src/app/components/v2/modal-share/modal-share.js
@@ -8,27 +8,28 @@ import Component from './modal-share-component';
 
 export const reduxConfig = { actions, reducers, initialState };
 
-const mapStateToProps = ({ modalShare, location }) => ({
-  isOpen: modalShare.isOpen,
-  currentLocation: `https://www.half-earthproject.org/maps?${  window.location.href.split('?')[1]}`,
-  urlToCopy: modalShare.urlToCopy,
-  linkActive: modalShare.linkActive,
-  coordinates: location && location.query && location.query.coordinates,
-  orientation: location && location.query && location.query.orientation,
-  shareSocialMedia: [
-    {
-      icon: facebookIcon,
-      link: `https://www.facebook.com/sharer/sharer.php?u=${`https://www.half-earthproject.org/maps?${ 
-        window.location.href.split('?')[1]}`}`,
-      className: 'facebookIcon'
-    },
-    {
-      icon: twitterIcon,
-      link: `https://twitter.com/intent/tweet?url=${`https://www.half-earthproject.org/maps?${ 
-        window.location.href.split('?')[1]}`}`,
-      className: 'twitterIcon'
-    }
-  ]
-});
+const mapStateToProps = ({ modalShare, location }) => {
+  const shareLocation = `https://www.half-earthproject.org/maps${window.location.search}`;
+  return {
+    isOpen: modalShare.isOpen,
+    currentLocation: shareLocation,
+    urlToCopy: modalShare.urlToCopy,
+    linkActive: modalShare.linkActive,
+    coordinates: location && location.query && location.query.coordinates,
+    orientation: location && location.query && location.query.orientation,
+    shareSocialMedia: [
+      {
+        icon: facebookIcon,
+        link: `https://www.facebook.com/sharer/sharer.php?u=${shareLocation}`,
+        className: 'facebookIcon'
+      },
+      {
+        icon: twitterIcon,
+        link: `https://twitter.com/intent/tweet?url=${shareLocation}`,
+        className: 'twitterIcon'
+      }
+    ]
+  };
+};
 
 export default connect(mapStateToProps, actions)(Component);

--- a/src/app/components/v2/modal-share/modal-share.js
+++ b/src/app/components/v2/modal-share/modal-share.js
@@ -10,7 +10,7 @@ export const reduxConfig = { actions, reducers, initialState };
 
 const mapStateToProps = ({ modalShare, location }) => ({
   isOpen: modalShare.isOpen,
-  currentLocation: window.location.href,
+  currentLocation: `https://www.half-earthproject.org/maps?${  window.location.href.split('?')[1]}`,
   urlToCopy: modalShare.urlToCopy,
   linkActive: modalShare.linkActive,
   coordinates: location && location.query && location.query.coordinates,
@@ -18,12 +18,14 @@ const mapStateToProps = ({ modalShare, location }) => ({
   shareSocialMedia: [
     {
       icon: facebookIcon,
-      link: `https://www.facebook.com/sharer/sharer.php?u=${window.location.href}`,
+      link: `https://www.facebook.com/sharer/sharer.php?u=${`https://www.half-earthproject.org/maps?${ 
+        window.location.href.split('?')[1]}`}`,
       className: 'facebookIcon'
     },
     {
       icon: twitterIcon,
-      link: `https://twitter.com/intent/tweet?url=${window.location.href}`,
+      link: `https://twitter.com/intent/tweet?url=${`https://www.half-earthproject.org/maps?${ 
+        window.location.href.split('?')[1]}`}`,
       className: 'twitterIcon'
     }
   ]

--- a/src/app/pages/root/toolbar/toolbar.js
+++ b/src/app/pages/root/toolbar/toolbar.js
@@ -33,8 +33,9 @@ class ToolbarContainer extends Component {
   handleShareClick = () => {
     this.props.setModalShareParams({
       isOpen: true,
-      currentLocation: window.location.href,
-      urlToCopy: window.location.href
+      currentLocation: `https://www.half-earthproject.org/maps?${ 
+        window.location.href.split('?')[1]}`,
+      urlToCopy: `https://www.half-earthproject.org/maps?${  window.location.href.split('?')[1]}`
     });
   };
 

--- a/src/app/pages/root/toolbar/toolbar.js
+++ b/src/app/pages/root/toolbar/toolbar.js
@@ -33,9 +33,8 @@ class ToolbarContainer extends Component {
   handleShareClick = () => {
     this.props.setModalShareParams({
       isOpen: true,
-      currentLocation: `https://www.half-earthproject.org/maps?${ 
-        window.location.href.split('?')[1]}`,
-      urlToCopy: `https://www.half-earthproject.org/maps?${  window.location.href.split('?')[1]}`
+      currentLocation: `https://www.half-earthproject.org/maps${window.location.search}`,
+      urlToCopy: `https://www.half-earthproject.org/maps${window.location.search}`
     });
   };
 


### PR DESCRIPTION
We need to use the production URL on the share modal, so that the users get the full experience.

Sadly my ES6 knowledge is not very good, so this might need some tweaking.