### PR TITLE
Unfeature/remove bivariate

### DIFF
--- a/src/app/pages/root/detail-view/detail-view-selectors.js
+++ b/src/app/pages/root/detail-view/detail-view-selectors.js
@@ -10,11 +10,22 @@ import { getDatasetsByCategory } from 'selectors/categories-selectors';
 import sortBy from 'lodash/sortBy';
 import snakeCase from 'lodash/snakeCase';
 
-const status = [ 'very low', 'low', 'average', 'high', 'very high' ];
+const status = [
+  { slug: 'very low', minValue: 0, maxValue: 0.20 },
+  { slug: 'low', minValue: 0.21, maxValue: 0.40 },
+  { slug: 'average', minValue: 0.41, maxValue: 0.60 },
+  { slug: 'high', minValue: 0.61, maxValue: 0.80 },
+  { slug: 'very high', minValue: 0.81, maxValue: 1 }
+];
 
-function getPosition(data, values) {
-  const position = sortBy(values).reduce((acc, next) => data > next ? acc + 1 : acc, 0);
-  return position;
+// Position from vibariate bins
+// function getPosition(data, values) {
+//   const position = sortBy(values).reduce((acc, next) => data > next ? acc + 1 : acc, 0);
+//   return position;
+// }
+function getStatus(rank) {
+  const st = status.find(s => rank > s.minValue && rank < s.maxValue);
+  return st.slug;
 }
 
 export const getCellData = createSelector([ getCellId, selectCellsData ], (cellId, cellsData) => {
@@ -150,21 +161,17 @@ export const getCellTaxaDataSelectedParsed = createSelector(
   [ getCellTaxaDataSelected, getHistogramBreaks ],
   (data, histogramBreaks) => {
     if (!data || !histogramBreaks) return undefined;
-    const rarityPosition = getPosition(data.rarity, histogramBreaks.rarity);
-    const richnessPosition = getPosition(data.richness, histogramBreaks.richness);
     return {
       ...data,
       rarity: {
         value: data.rarity,
         ranked_rarity: data.ranked_rarity,
-        position: rarityPosition,
-        status: status[rarityPosition]
+        status: getStatus(data.ranked_rarity)
       },
       richness: {
         value: data.richness,
         ranked_richness: data.ranked_richness,
-        position: richnessPosition,
-        status: status[richnessPosition]
+        status: getStatus(data.ranked_richness)
       }
     };
   }

--- a/src/app/pages/root/detail-view/rarity-richness/rarity-richness-component.jsx
+++ b/src/app/pages/root/detail-view/rarity-richness/rarity-richness-component.jsx
@@ -1,10 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Loading, Dropdown, Button, Icon } from 'he-components';
+import { Loading, Dropdown } from 'he-components';
 
-import infoIcon from 'assets/icons/icon-info.svg';
-
-import Histogram from './histogram';
 import styles from './rarity-richness-styles';
 
 class RarityRichnessComponent extends Component {
@@ -14,9 +11,9 @@ class RarityRichnessComponent extends Component {
       data = {},
       taxas,
       selected,
-      histogram,
-      handleTaxasChange,
-      handleMetadataClick
+      // histogram,
+      // handleMetadataClick
+      handleTaxasChange
     } = this.props;
     const { richness, rarity } = data;
 
@@ -41,16 +38,11 @@ class RarityRichnessComponent extends Component {
             <span className={styles.highlight}>{richness.status}</span>
             {' '}richness {richnessStatement} and{' '}
             <span className={styles.highlight}>{rarity.status}</span>
-            {' '}rarity {rarityStatement}.
+            {' '}range rarity {rarityStatement}.
           </span>
             )
         }
-        <div className={styles.histogramContainer}>
-          <Histogram data={data} values={histogram} />
-          <Button theme={styles} onClick={handleMetadataClick}>
-            <Icon icon={infoIcon} />
-          </Button>
-        </div>
+        {}
       </div>
     );
   }
@@ -61,17 +53,17 @@ RarityRichnessComponent.propTypes = {
   loading: PropTypes.bool,
   taxas: PropTypes.array,
   selected: PropTypes.object,
-  histogram: PropTypes.shape({ richness: PropTypes.array, rarity: PropTypes.array }),
-  handleTaxasChange: PropTypes.func.isRequired,
-  handleMetadataClick: PropTypes.func.isRequired
+  // histogram: PropTypes.shape({ richness: PropTypes.array, rarity: PropTypes.array }),
+  // handleMetadataClick: PropTypes.func.isRequired
+  handleTaxasChange: PropTypes.func.isRequired
 };
 
 RarityRichnessComponent.defaultProps = {
   loading: false,
   data: undefined,
   taxas: [],
-  selected: {},
-  histogram: null
+  // histogram: null
+  selected: {}
 };
 
 export default RarityRichnessComponent;

--- a/src/app/pages/root/detail-view/species-to-watch/mol-species-link/mol-species-link-component.jsx
+++ b/src/app/pages/root/detail-view/species-to-watch/mol-species-link/mol-species-link-component.jsx
@@ -18,10 +18,10 @@ const MolSpeciesLinkComponent = props => {
 
 MolSpeciesLinkComponent.propTypes = {
   scientificName: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   className: PropTypes.string
 };
 
-MolSpeciesLinkComponent.defaultProps = { className: '' };
+MolSpeciesLinkComponent.defaultProps = { className: '', children: {} };
 
 export default MolSpeciesLinkComponent;

--- a/src/app/pages/root/detail-view/species-to-watch/mol-species-link/mol-species-link-component.jsx
+++ b/src/app/pages/root/detail-view/species-to-watch/mol-species-link/mol-species-link-component.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { snakeCase } from 'lodash';
+
+const MolSpeciesLinkComponent = props => {
+  const { scientificName, children, className } = props;
+  return (
+    <a
+      className={className}
+      href={`https://mol.org/species/${snakeCase(scientificName)}`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {children}
+    </a>
+  );
+};
+
+MolSpeciesLinkComponent.propTypes = {
+  scientificName: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string
+};
+
+MolSpeciesLinkComponent.defaultProps = { className: '' };
+
+export default MolSpeciesLinkComponent;

--- a/src/app/pages/root/detail-view/species-to-watch/mol-species-link/mol-species-link.js
+++ b/src/app/pages/root/detail-view/species-to-watch/mol-species-link/mol-species-link.js
@@ -1,0 +1,3 @@
+import Component from './mol-species-link-component';
+
+export default Component;

--- a/src/app/pages/root/detail-view/species-to-watch/species-to-watch-component.jsx
+++ b/src/app/pages/root/detail-view/species-to-watch/species-to-watch-component.jsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { snakeCase } from 'lodash';
 import { Loading } from 'he-components';
 import cx from 'classnames';
+import MolSpeciesLink from './mol-species-link';
 
 import styles from './species-to-watch-styles';
 
@@ -22,22 +22,28 @@ class SpeciesToWatchComponent extends Component {
             <div className={styles.speciesRow} key={specie.commonname || specie.scientificname}>
               {
                     (
-                      <a
-                        href={`https://mol.org/species/${snakeCase(specie.scientificname)}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
+                      <MolSpeciesLink scientificName={specie.scientificname}>
                         <img
                           className={styles.speciesImg}
                           src={specie.image && specie.image.url || 'img/species-placeholder@2x.png'}
                           alt={`${specie.commonname} specie`}
                         />
-                      </a>
+                      </MolSpeciesLink>
                     )
                   }
               <div className={styles.speciesContent}>
-                <h4 className={styles.speciesTitle}>{specie.commonname}</h4>
-                <p className={styles.speciesSubTitle}>{specie.scientificname}</p>
+                <MolSpeciesLink
+                  scientificName={specie.scientificname}
+                  className={styles.speciesTitle}
+                >
+                  {specie.commonname}
+                </MolSpeciesLink>
+                <MolSpeciesLink
+                  scientificName={specie.scientificname}
+                  className={styles.speciesSubTitle}
+                >
+                  {specie.scientificname}
+                </MolSpeciesLink>
                 {
                       specie.iucn && (
                       <a

--- a/src/app/pages/root/detail-view/species-to-watch/species-to-watch-styles.scss
+++ b/src/app/pages/root/detail-view/species-to-watch/species-to-watch-styles.scss
@@ -45,6 +45,7 @@
   letter-spacing: 1.7px;
   color: $color-white;
   margin: 0;
+  text-decoration: none;
 }
 
 .specieLink {
@@ -60,6 +61,7 @@
   letter-spacing: normal;
   color: #495a64;
   margin: 5px 0;
+  text-decoration: none;
 }
 
 .speciesCategory {


### PR DESCRIPTION
This PR removes bivariate plot from rarity and richness section on the landscape view sidebar.
https://www.pivotaltracker.com/story/show/161336937
It also makes species names linkable on `species to watch` section.
https://www.pivotaltracker.com/story/show/161213055