### PR TITLE
Fix/moving camera on geometry selection

### DIFF
--- a/src/app/components/v2/dataset-combo/dataset-combo.js
+++ b/src/app/components/v2/dataset-combo/dataset-combo.js
@@ -21,7 +21,15 @@ class DatasetComboContainer extends Component {
     const coordinates = bounds
       ? Cesium.Rectangle.fromDegrees(...bounds)
       : query && query.coordinates;
-    updateQueryParam({ query: { ...query, activeLayers, coordinates, activeMarker: undefined } });
+    updateQueryParam({
+      query: {
+        ...query,
+        activeLayers,
+        coordinates,
+        activeMarker: undefined,
+        reservesTooltip: undefined
+      }
+    });
   };
 
   handleMultiLayerClick = ({ slug, active }) => {

--- a/src/app/components/v2/map-tooltip/map-tooltip-component.jsx
+++ b/src/app/components/v2/map-tooltip/map-tooltip-component.jsx
@@ -77,8 +77,8 @@ class MapTooltipComponent extends Component {
       <div
         className={styles.container}
         style={{
-          transform: `translate(${tooltipPosition.x - this.width}px, ${tooltipPosition.y -
-            this.height}px)`
+          transform: `translate(calc(${tooltipPosition.x}px - 50%), calc(${tooltipPosition.y -
+            18}px - 100%)`
         }}
         ref={tooltip => {
           this.tooltip = tooltip;

--- a/src/app/components/v2/map/map.js
+++ b/src/app/components/v2/map/map.js
@@ -64,6 +64,7 @@ class CesiumComponent extends Component {
       terrainMode,
       terrainCameraOffset,
       cellCoordinates,
+      cellId,
       layers
     } = this.props;
     if (this.viewer) {
@@ -77,7 +78,7 @@ class CesiumComponent extends Component {
       if (camera && prevProps.camera !== camera) this.setCamera();
       if (lockNavigation) disablePanning(this.viewer);
       if (terrainMode) {
-        if (cellCoordinates) {
+        if (cellCoordinates && prevProps.cellId !== cellId) {
           this.renderGridCell(cellCoordinates, this.rectangle);
           this.setTerrainModeView(cellCoordinates, terrainCameraOffset);
         }
@@ -280,6 +281,7 @@ CesiumComponent.propTypes = {
   lockNavigation: PropTypes.bool,
   rotate: PropTypes.func,
   coordinates: PropTypes.object,
+  cellId: PropTypes.number,
   coordinatesOptions: PropTypes.object,
   camera: PropTypes.object,
   terrainMode: PropTypes.bool,
@@ -307,6 +309,7 @@ CesiumComponent.defaultProps = {
   rotate: null,
   lockNavigation: false,
   coordinates: undefined,
+  cellId: undefined,
   coordinatesOptions: undefined,
   camera: null,
   terrainMode: false,

--- a/src/app/pages/root/legend/legend.js
+++ b/src/app/pages/root/legend/legend.js
@@ -68,7 +68,9 @@ class LegendContainer extends Component {
   updateLayersActive = layers => {
     const { updateQueryParam, query = {} } = this.props;
     const activeLayers = getLayersActiveMerged(layers, query.activeLayers);
-    updateQueryParam({ query: { ...query, activeLayers, activeMarker: undefined } });
+    updateQueryParam({
+      query: { ...query, activeLayers, activeMarker: undefined, reservesTooltip: undefined }
+    });
   };
 
   updateLayersProperty(slugs, { key, value }) {

--- a/src/app/pages/root/map/map-component.jsx
+++ b/src/app/pages/root/map/map-component.jsx
@@ -302,6 +302,7 @@ class MapComponent extends PureComponent {
       protectedAreasAcive,
       protectedAreasLayers,
       coordinates,
+      activeGridCellId,
       coordinatesOptions,
       updateMapParams,
       terrainCameraOffset,
@@ -327,6 +328,7 @@ class MapComponent extends PureComponent {
         coordinatesOptions={coordinatesOptions}
         terrainCameraOffset={terrainCameraOffset}
         cellCoordinates={cellCoordinates}
+        cellId={activeGridCellId}
         onMouseMove={this.handleMouseMove}
         onMouseClick={this.handleMouseClick}
         onDoubleClick={this.handleDoubleClick}
@@ -425,7 +427,7 @@ MapComponent.propTypes = {
   cellCoordinates: PropTypes.array,
   activeMarker: PropTypes.string,
   reservesTooltip: PropTypes.bool,
-  activeGridCellId: PropTypes.string,
+  activeGridCellId: PropTypes.number,
   updateMapParams: PropTypes.func
 };
 


### PR DESCRIPTION
This PR avoids camera position reset when selecting a protected area on landscape view.
https://www.pivotaltracker.com/story/show/161215329

![kapture 2018-10-22 at 18 37 21](https://user-images.githubusercontent.com/6906348/47305386-9ebd2800-d629-11e8-96ad-92bc421337d6.gif)
