### PR TITLE
High priority analytics events

### DIFF
--- a/src/app/components/v2/dataset-combo/dataset-combo-actions.js
+++ b/src/app/components/v2/dataset-combo/dataset-combo-actions.js
@@ -2,3 +2,13 @@ import { createAction } from 'redux-tools';
 import { APPv2 } from 'router';
 
 export const updateQueryParam = createAction(APPv2);
+
+export const addLayerAnalyticsEvent = createAction('addLayer', null, ({ slug, query }) => {
+  const viewMode = query && query.terrain ? 'Landscape view' : 'Map menu';
+  return { analytics: [ viewMode, 'Add layer', `${slug}` ] };
+});
+
+export const removeLayerAnalyticsEvent = createAction('removeLayer', null, ({ slug, query }) => {
+  const viewMode = query && query.terrain ? 'Landscape view' : 'Map menu';
+  return { analytics: [ viewMode, 'Remove layer', `${slug}` ] };
+});

--- a/src/app/components/v2/dataset-combo/dataset-combo.js
+++ b/src/app/components/v2/dataset-combo/dataset-combo.js
@@ -38,7 +38,12 @@ class DatasetComboContainer extends Component {
   };
 
   handleLayerClick = (layers, { slug, active, layerConfig }) => {
-    const { layerDefaultOpacity } = this.props;
+    const {
+      layerDefaultOpacity,
+      addLayerAnalyticsEvent,
+      removeLayerAnalyticsEvent,
+      query
+    } = this.props;
     const { landscape_opacity } = layerConfig.body && layerConfig.body;
     const activeLayers = layers.map(layer => ({
       slug: layer.slug,
@@ -49,7 +54,12 @@ class DatasetComboContainer extends Component {
     }));
 
     const activeLayer = activeLayers.find(layer => layer.active);
-    this.props.fetchModalMetaData(activeLayer.slug);
+    if (activeLayer) {
+      addLayerAnalyticsEvent({ slug, query });
+    } else {
+      removeLayerAnalyticsEvent({ slug, query });
+    }
+    fetchModalMetaData(activeLayer.slug);
 
     const { bbox } = layerConfig.body && layerConfig.body;
     if (bbox && bbox.length === 4) {
@@ -60,7 +70,12 @@ class DatasetComboContainer extends Component {
   };
 
   handleSwitchChange = (category, slug, active) => {
-    const { layerDefaultOpacity } = this.props;
+    const {
+      layerDefaultOpacity,
+      addLayerAnalyticsEvent,
+      removeLayerAnalyticsEvent,
+      query
+    } = this.props;
     let layersToUpdate = [];
     if (category.multiSelect) {
       const dataset = category.datasets.find(d => d.slug === slug);
@@ -96,7 +111,10 @@ class DatasetComboContainer extends Component {
     const layerToActive = layersToUpdate && layersToUpdate.find(l => l.active);
 
     if (layerToActive) {
-      this.props.fetchModalMetaData(layerToActive.slug);
+      fetchModalMetaData(layerToActive.slug);
+      addLayerAnalyticsEvent({ slug: layerToActive.slug, query });
+    } else {
+      removeLayerAnalyticsEvent({ slug, query });
     }
 
     const bbox = layerToActive && layerToActive.bbox;
@@ -122,6 +140,8 @@ class DatasetComboContainer extends Component {
 DatasetComboContainer.propTypes = {
   updateQueryParam: PropTypes.func.isRequired,
   fetchModalMetaData: PropTypes.func.isRequired,
+  addLayerAnalyticsEvent: PropTypes.func.isRequired,
+  removeLayerAnalyticsEvent: PropTypes.func.isRequired,
   query: PropTypes.object,
   layerDefaultOpacity: PropTypes.number
 };

--- a/src/app/components/v2/modal-share/modal-share-actions.js
+++ b/src/app/components/v2/modal-share/modal-share-actions.js
@@ -1,3 +1,7 @@
 import { createAction } from 'redux-tools';
 
 export const setModalShareParams = createAction('setModalShareParams');
+
+export const urlShareAnalyticsEvent = createAction('shareUrl', null, ({ url, shareType }) => ({
+  analytics: [ 'Share', shareType, `${url}` ]
+}));

--- a/src/app/components/v2/modal-share/modal-share-component.jsx
+++ b/src/app/components/v2/modal-share/modal-share-component.jsx
@@ -9,14 +9,16 @@ import styles from './modal-share-styles';
 
 class ModalShareComponent extends Component {
   handleLinkButtonClick = () => {
-    const { setModalShareParams, currentLocation } = this.props;
+    const { setModalShareParams, currentLocation, urlShareAnalyticsEvent } = this.props;
     setModalShareParams({ linkActive: true, urlToCopy: currentLocation });
+    urlShareAnalyticsEvent({ url: currentLocation, shareType: 'Link' });
   };
 
   handleEmbedButtonClick = () => {
-    const { setModalShareParams, currentLocation } = this.props;
+    const { setModalShareParams, currentLocation, urlShareAnalyticsEvent } = this.props;
     const embed = `<iframe id="map-iframe" src="${currentLocation}" />`;
     setModalShareParams({ linkActive: false, urlToCopy: embed });
+    urlShareAnalyticsEvent({ url: currentLocation, shareType: 'Embed' });
   };
 
   handleModalClose = () => {
@@ -120,6 +122,7 @@ ModalShareComponent.propTypes = {
   isOpen: PropTypes.bool,
   currentLocation: PropTypes.string,
   setModalShareParams: PropTypes.func.isRequired,
+  urlShareAnalyticsEvent: PropTypes.func.isRequired,
   linkActive: PropTypes.bool,
   coordinates: PropTypes.shape({}),
   orientation: PropTypes.array,

--- a/src/app/pages/root/detail-view/detail-view-actions.js
+++ b/src/app/pages/root/detail-view/detail-view-actions.js
@@ -2,3 +2,7 @@ import { createAction } from 'redux-tools';
 import { APPv2 } from 'router';
 
 export const updateQueryParam = createAction(APPv2);
+
+export const taxasChangeAnalyticsEvent = createAction('selectTaxa', null, taxaName => ({
+  analytics: [ 'Landscape view', 'Filter species', `${taxaName}` ]
+}));

--- a/src/app/pages/root/detail-view/detail-view.js
+++ b/src/app/pages/root/detail-view/detail-view.js
@@ -41,8 +41,9 @@ class DetailViewContainer extends Component {
   };
 
   handleTaxasChange = taxa => {
-    const { updateQueryParam, query } = this.props;
+    const { updateQueryParam, query, taxasChangeAnalyticsEvent } = this.props;
     updateQueryParam({ query: { ...query, taxa: taxa.slug } });
+    taxasChangeAnalyticsEvent(taxa.slug);
   };
 
   render() {
@@ -60,6 +61,7 @@ DetailViewContainer.propTypes = {
   query: PropTypes.object.isRequired,
   fetchCellDetail: PropTypes.func.isRequired,
   updateQueryParam: PropTypes.func.isRequired,
+  taxasChangeAnalyticsEvent: PropTypes.func.isRequired,
   cellId: PropTypes.string.isRequired
 };
 

--- a/src/app/pages/root/map/map-actions.js
+++ b/src/app/pages/root/map/map-actions.js
@@ -2,3 +2,7 @@ import { createAction } from 'redux-tools';
 import { APPv2 } from 'router';
 
 export const updateQueryParam = createAction(APPv2);
+
+export const gridCellSelectionAnalyticsEvent = createAction('selectGridCell', null, cellId => ({
+  analytics: [ 'Landscape view', 'User clicks an area', `${cellId}` ]
+}));

--- a/src/app/pages/root/map/map-component.jsx
+++ b/src/app/pages/root/map/map-component.jsx
@@ -242,9 +242,10 @@ class MapComponent extends PureComponent {
 
   handleGridClick = object => {
     // if we are clicking in th active grid cell do nothing
-    const { activeGridCellId } = this.props;
+    const { activeGridCellId, gridCellSelectionAnalyticsEvent } = this.props;
     if (activeGridCellId && activeGridCellId === object.id.cellId) return null;
     this.setMapTerrain(object.id.cellId, object.id.coordinates);
+    gridCellSelectionAnalyticsEvent(object.id.cellId);
     return object.id.cellId;
   };
 
@@ -428,7 +429,8 @@ MapComponent.propTypes = {
   activeMarker: PropTypes.string,
   reservesTooltip: PropTypes.bool,
   activeGridCellId: PropTypes.number,
-  updateMapParams: PropTypes.func
+  updateMapParams: PropTypes.func,
+  gridCellSelectionAnalyticsEvent: PropTypes.func.isRequired
 };
 
 MapComponent.defaultProps = {


### PR DESCRIPTION
This PR adds `high` priority analytics events as described in this document:
https://docs.google.com/spreadsheets/d/1LbFZhalG7eXhyx5r2sTmdjLNGUtlcA7SXMOJ2aT8lEA/edit#gid=0

Analytic events will get fired when:
- Toggling layers (both in map and landscape view).
-  Selecting a grid Cell (and entering landscape view).
-  Selecting some taxa on landscape view.
-  Selecting `embed` or `link` on share modal.

__NOTE:__ Remember to add `GOOGLE_ANALYTICS` variable to your `.env` file.