### PR TITLE
Fix/featured categories images path

### DIFF
--- a/src/app/pages/root/categories-list/categories-list-component.jsx
+++ b/src/app/pages/root/categories-list/categories-list-component.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Button, Icon } from 'he-components';
 import DatasetCombo from 'components/v2/dataset-combo';
+import { filenameFromPath } from 'utils';
 
 import infoIcon from 'assets/icons/icon-info.svg';
 import styles from './categories-list-styles';
@@ -44,10 +45,12 @@ class CategoriesListComponent extends Component {
   }
 
   renderFeaturedCategory(category) {
+    const imgUrl = category.imageUrl;
+    const imgFileName = filenameFromPath(imgUrl);
     return (
       <div className={styles.featuredCategory} key={category.slug}>
         <div
-          style={{ backgroundImage: `url(${category.imageUrl})` }}
+          style={{ backgroundImage: `url(img/categories/${imgFileName})` }}
           className={styles.featuredImage}
         />
         <div className={styles.featuredCategoryContentContainer}>

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -10,7 +10,12 @@ export const cartoConfig = (account, cartocss, table, options = {}) => ({
     layers: [
       {
         type: 'mapnik',
-        options: { cartocss_version: '2.3.0', cartocss, sql: options.sql || `select * from ${table}`, ...options }
+        options: {
+          cartocss_version: '2.3.0',
+          cartocss,
+          sql: options.sql || `select * from ${table}`,
+          ...options
+        }
       }
     ]
   }
@@ -26,3 +31,5 @@ export const colorMap = { blue: '#0664f6', purple: '#8366e4', violet: '#9632b2' 
 export const pick = (o, k) => o && o[k] || o;
 
 export const checkBoolean = bool => typeof bool === 'string' ? bool === 'true' : bool;
+
+export const filenameFromPath = path => path.substring(path.lastIndexOf('/') + 1);


### PR DESCRIPTION
This PR avoids `featured category` images to be fetched from the `staging` server, and instead be consumed from the project repo.
This is just a quick fix and the proper solution would be to have the relative path available on the layer json data (instead of the `staging` server URL).

Note: I didn't fix the missing images on layer legend, to do that we need to change the URL on [layer's `legendConfig`](https://github.com/Vizzuality/half-earth/blob/feature/add_data_work/data/layers/places_to_watch.json#L17) to also point to the relative path.

This error is only visible when `staging` server is not working properly (there is some kind of recurrent cache error that comes and goes).