### PR TITLE
Update cesium version

### DIFF
--- a/src/tpl.ejs
+++ b/src/tpl.ejs
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="./styles/fonts.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-beta1/katex.min.css">
     <meta content="width=device-width, initial-scale=1" name="viewport" />
-    <script src="https://cesiumjs.org/releases/1.53/Build/Cesium/Cesium.js"></script>
+    <script src="https://cesiumjs.org/releases/1.54/Build/Cesium/Cesium.js"></script>
     <style media="screen">.cesium-viewer-selectionIndicatorContainer, .cesium-viewer-infoBoxContainer, .cesium-widget-credits { display: none !important }</style>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
This PR updates Cesium version to `1.54`.
The issue solved with PR #404 showed up again.
Seems that [terrain provider should be changed](https://groups.google.com/forum/#!topic/cesium-dev/dclHaPSP3Og) in order to fix this issue definitely.