### PR TITLE
Add hotjar script to head tag

### DIFF
--- a/src/tpl.ejs
+++ b/src/tpl.ejs
@@ -18,6 +18,17 @@
 
       ga('create', <%= htmlWebpackPlugin.options.GOOGLE_ANALYTICS %>, 'auto');
     </script>
+    <!-- Hotjar Tracking Code for half-earthproject.org -->
+    <script>
+      (function(h,o,t,j,a,r){
+          h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+          h._hjSettings={hjid:1260411,hjsv:6};
+          a=o.getElementsByTagName('head')[0];
+          r=o.createElement('script');r.async=1;
+          r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+          a.appendChild(r);
+      })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+    </script>
   </head>
   <body>
     <div id="boot"></div>


### PR DESCRIPTION
This PR adds E.O Wilson Biodiversity Foundation hotjar `script` to `head` tag to allow [Hotjar](https://www.hotjar.com/) analytics on the map.

Once this PR is deployed site URL should be verified on hotjar dashboard.